### PR TITLE
feat: discard hand at player turn end

### DIFF
--- a/scenes/encounters/battle.tscn
+++ b/scenes/encounters/battle.tscn
@@ -92,6 +92,9 @@ grow_horizontal = 0
 grow_vertical = 0
 texture = SubResource("GradientTexture2D_1mqim")
 
+[node name="CardHandler" type="Node2D" parent="." groups=["card_piles"]]
+script = ExtResource("2_8apll")
+
 [node name="StateMachine" type="Node" parent="."]
 script = ExtResource("1_g3s1b")
 
@@ -125,9 +128,6 @@ script = ExtResource("9_mqlpk")
 [node name="Background" type="Sprite2D" parent="."]
 texture = ExtResource("1_pfikb")
 centered = false
-
-[node name="CardHandler" type="Node2D" parent="." groups=["card_piles"]]
-script = ExtResource("2_8apll")
 
 [node name="EnemyHandler" type="Node2D" parent="."]
 script = ExtResource("3_5ildr")

--- a/scripts/battle/state_machine/enemy_end_turn.gd
+++ b/scripts/battle/state_machine/enemy_end_turn.gd
@@ -5,7 +5,7 @@ func enter():
 	print("Entered EnemyEndTurn")
 	# 1. for each enemy: resolve enemy end of turn effects
 	# 2. enter state player_start_turn
-	await get_tree().create_timer(2.0).timeout
+	await get_tree().create_timer(1.0).timeout
 	state_machine.transition_to("PlayerStartTurn")
 
 func exit():

--- a/scripts/battle/state_machine/enemy_start_turn.gd
+++ b/scripts/battle/state_machine/enemy_start_turn.gd
@@ -5,7 +5,7 @@ func enter():
 	print("Entered EnemyStartTurn")
 	# 1. for each enemy: resolve enemy start of turn effects
 	# 2. enter state enemy_turn
-	await get_tree().create_timer(2.0).timeout
+	await get_tree().create_timer(1.0).timeout
 	state_machine.transition_to("EnemyTurn")
 
 func exit():

--- a/scripts/battle/state_machine/enemy_turn.gd
+++ b/scripts/battle/state_machine/enemy_turn.gd
@@ -5,7 +5,7 @@ func enter():
 	print("Entered EnemyTurn")
 	# 1. for each enemy: resolve enemy intent ('act')
 	# 2. enter state enemy_end_turn
-	await get_tree().create_timer(2.0).timeout
+	await get_tree().create_timer(1.0).timeout
 	state_machine.transition_to("EnemyEndTurn")
 
 func exit():

--- a/scripts/battle/state_machine/player_end_turn.gd
+++ b/scripts/battle/state_machine/player_end_turn.gd
@@ -6,7 +6,10 @@ func enter():
 	# 1. resolve player end of turn effects
 	# 2. discard hand
 	# 3. enter state enemy_start_turn
-	await get_tree().create_timer(2.0).timeout
+	
+	EventBusHandler.call_event(EventBus.Event.PLAYER_TURN_END)
+	
+	await get_tree().create_timer(1.0).timeout
 	state_machine.transition_to("EnemyStartTurn")
 
 func exit():

--- a/scripts/battle/state_machine/player_start_turn.gd
+++ b/scripts/battle/state_machine/player_start_turn.gd
@@ -4,11 +4,16 @@ extends State
 func enter():
 	print("Entered PlayerStartTurn")
 	battle_ui.set_end_turn_button_enabled(false)
-	await get_tree().create_timer(2.0).timeout
+	
 	# 1. choose enemy intent
 	# 2. resolve start of turn effects
 	# 3. draw cards
 	# 4. enter state idle
+	
+	EventBusHandler.call_event(EventBus.Event.PLAYER_TURN_START)
+	
+	await get_tree().create_timer(1.0).timeout
+	
 	state_machine.transition_to("Idle")
 
 func exit():


### PR DESCRIPTION
Added a function to discard the players hand at the end of his turn. Additionally implemented the drawing and discarding into the state machine.

closes #86