### PR TITLE
fix: battle state machine transition triggers

### DIFF
--- a/scenes/encounters/battle.tscn
+++ b/scenes/encounters/battle.tscn
@@ -100,12 +100,9 @@ texture = ExtResource("16_7id2p")
 position = Vector2(310, 81)
 texture = ExtResource("17_tt5ef")
 
-[connection signal="choose_enemy_intents" from="StateMachine/PlayerStartTurn" to="." method="_on_player_start_turn_choose_enemy_intents"]
-[connection signal="draw_cards" from="StateMachine/PlayerStartTurn" to="." method="_on_player_start_turn_draw_cards"]
 [connection signal="player_starts_turn" from="StateMachine/PlayerStartTurn" to="." method="_on_player_start_turn_player_starts_turn"]
 [connection signal="entered_idle" from="StateMachine/Idle" to="." method="_on_idle_entered_idle"]
 [connection signal="exited_idle" from="StateMachine/Idle" to="." method="_on_idle_exited_idle"]
-[connection signal="discard_hand" from="StateMachine/PlayerEndTurn" to="." method="_on_player_end_turn_discard_hand"]
 [connection signal="player_ends_turn" from="StateMachine/PlayerEndTurn" to="." method="_on_player_end_turn_player_ends_turn"]
 [connection signal="enemy_starts_turn" from="StateMachine/EnemyStartTurn" to="." method="_on_enemy_start_turn_enemy_starts_turn"]
 [connection signal="resolve_enemy_intents" from="StateMachine/EnemyTurn" to="." method="_on_enemy_turn_resolve_enemy_intents"]

--- a/scripts/battle/battle.gd
+++ b/scripts/battle/battle.gd
@@ -33,20 +33,16 @@ func _exit_tree() -> void:
 
 #region player turn
 
-func _on_player_start_turn_draw_cards() -> void:
-	card_handler.draw_cards(RunData.player_stats.card_draw_amount)
-
-func _on_player_start_turn_choose_enemy_intents() -> void:
-	enemy_handler.choose_intent()
-
 func _on_player_start_turn_player_starts_turn() -> void:
-	player_character.start_of_turn()
+	enemy_handler.choose_intent()
+	await player_character.start_of_turn()
+	await card_handler.draw_cards(RunData.player_stats.card_draw_amount)
+	EventBusHandler.player_start_of_turn_resolved.emit()
 
 func _on_player_end_turn_player_ends_turn() -> void:
-	player_character.end_of_turn()
-
-func _on_player_end_turn_discard_hand():
-	card_handler.discard_hand()
+	await player_character.end_of_turn()
+	await card_handler.discard_hand()
+	EventBusHandler.player_end_of_turn_resolved.emit()
 
 func _on_idle_entered_idle():
 	card_handler.player_turn = true
@@ -59,15 +55,19 @@ func _on_idle_exited_idle():
 #region enemy turn
 
 func _on_enemy_turn_resolve_enemy_intents() -> void:
-	enemy_handler.resolve_intent()
+	await enemy_handler.resolve_intent()
+	EventBusHandler.enemies_turn_resolved.emit()
 
 func _on_enemy_start_turn_enemy_starts_turn() -> void:
 	for enemy in enemy_handler.enemies:
-		enemy.start_of_turn()
+		await enemy.start_of_turn()
+	EventBusHandler.enemies_start_of_turn_resolved.emit()
 
 func _on_enemy_end_turn_enemy_ends_turn() -> void:
 	for enemy in enemy_handler.enemies:
-		enemy.end_of_turn()
+		await enemy.end_of_turn()
+	EventBusHandler.enemies_end_of_turn_resolved.emit()
+
 #endregion
 
 func _on_player_character_player_died() -> void:

--- a/scripts/battle/battle.gd
+++ b/scripts/battle/battle.gd
@@ -37,12 +37,12 @@ func _on_player_start_turn_player_starts_turn() -> void:
 	enemy_handler.choose_intent()
 	await player_character.start_of_turn()
 	await card_handler.draw_cards(RunData.player_stats.card_draw_amount)
-	EventBusHandler.player_start_of_turn_resolved.emit()
+	state_machine.transition_to("Idle")
 
 func _on_player_end_turn_player_ends_turn() -> void:
 	await player_character.end_of_turn()
 	await card_handler.discard_hand()
-	EventBusHandler.player_end_of_turn_resolved.emit()
+	state_machine.transition_to("EnemyStartTurn")
 
 func _on_idle_entered_idle():
 	card_handler.player_turn = true
@@ -56,17 +56,17 @@ func _on_idle_exited_idle():
 
 func _on_enemy_turn_resolve_enemy_intents() -> void:
 	await enemy_handler.resolve_intent()
-	EventBusHandler.enemies_turn_resolved.emit()
+	state_machine.transition_to("EnemyEndTurn")
 
 func _on_enemy_start_turn_enemy_starts_turn() -> void:
 	for enemy in enemy_handler.enemies:
 		await enemy.start_of_turn()
-	EventBusHandler.enemies_start_of_turn_resolved.emit()
+	state_machine.transition_to("EnemyTurn")
 
 func _on_enemy_end_turn_enemy_ends_turn() -> void:
 	for enemy in enemy_handler.enemies:
 		await enemy.end_of_turn()
-	EventBusHandler.enemies_end_of_turn_resolved.emit()
+	state_machine.transition_to("PlayerStartTurn")
 
 #endregion
 

--- a/scripts/battle/card_handler.gd
+++ b/scripts/battle/card_handler.gd
@@ -84,8 +84,7 @@ func draw_cards(amount: int) -> void:
 		EventBusHandler.card_piles_card_count_changed.emit(draw_pile.size(), discard_pile.size())
 		
 		# wait for hand to be updated
-		var timer = get_tree().create_timer(CARD_DRAW_SPEED)
-		await timer.timeout
+		await get_tree().create_timer(CARD_DRAW_SPEED).timeout
 	
 	EventBusHandler.cards_drawn.emit()
 	
@@ -122,6 +121,7 @@ func discard_hand() -> void:
 	while hand.size() > 0:
 		var card = hand.back()
 		await discard_card(card)
+	await get_tree().create_timer(0.4).timeout
 
 func discard_card(card: Card) -> void:
 	

--- a/scripts/battle/enemy_handler.gd
+++ b/scripts/battle/enemy_handler.gd
@@ -41,8 +41,7 @@ func _calculate_enemy_x_position(index: int, enemy_count: int) -> int:
 func resolve_intent():
 	for enemy in enemies:
 		await enemy.resolve_intent()
-		var timer = get_tree().create_timer(0.8)
-		await timer.timeout
+		await get_tree().create_timer(0.8).timeout
 
 func choose_intent():
 	for enemy in enemies:

--- a/scripts/battle/state_machine/enemy_end_turn.gd
+++ b/scripts/battle/state_machine/enemy_end_turn.gd
@@ -4,9 +4,6 @@ extends State
 signal enemy_ends_turn
 
 
-func _ready() -> void:
-	EventBusHandler.enemies_end_of_turn_resolved.connect(_on_event_bus_enemies_end_of_turn_resolved)
-
 func enter():
 	print("Entered EnemyEndTurn")
 	# for each enemy: resolve enemy end of turn effects
@@ -14,6 +11,3 @@ func enter():
 
 func exit():
 	print("Exited EnemyEndTurn")
-
-func _on_event_bus_enemies_end_of_turn_resolved():
-	state_machine.transition_to("PlayerStartTurn")

--- a/scripts/battle/state_machine/enemy_end_turn.gd
+++ b/scripts/battle/state_machine/enemy_end_turn.gd
@@ -5,7 +5,7 @@ signal enemy_ends_turn
 
 
 func _ready() -> void:
-	EventBusHandler.enemies_end_of_turn_resolved.connect(_on_event_bus_handler_enemies_end_of_turn_resolved)
+	EventBusHandler.enemies_end_of_turn_resolved.connect(_on_event_bus_enemies_end_of_turn_resolved)
 
 func enter():
 	print("Entered EnemyEndTurn")
@@ -15,5 +15,5 @@ func enter():
 func exit():
 	print("Exited EnemyEndTurn")
 
-func _on_event_bus_handler_enemies_end_of_turn_resolved():
+func _on_event_bus_enemies_end_of_turn_resolved():
 	state_machine.transition_to("PlayerStartTurn")

--- a/scripts/battle/state_machine/enemy_end_turn.gd
+++ b/scripts/battle/state_machine/enemy_end_turn.gd
@@ -3,13 +3,17 @@ extends State
 
 signal enemy_ends_turn
 
+
+func _ready() -> void:
+	EventBusHandler.enemies_end_of_turn_resolved.connect(_on_event_bus_handler_enemies_end_of_turn_resolved)
+
 func enter():
 	print("Entered EnemyEndTurn")
-	# 1. for each enemy: resolve enemy end of turn effects
+	# for each enemy: resolve enemy end of turn effects
 	enemy_ends_turn.emit()
-	# 2. enter state player_start_turn
-	await get_tree().create_timer(1.0).timeout
-	state_machine.transition_to("PlayerStartTurn")
 
 func exit():
 	print("Exited EnemyEndTurn")
+
+func _on_event_bus_handler_enemies_end_of_turn_resolved():
+	state_machine.transition_to("PlayerStartTurn")

--- a/scripts/battle/state_machine/enemy_start_turn.gd
+++ b/scripts/battle/state_machine/enemy_start_turn.gd
@@ -4,9 +4,6 @@ extends State
 signal enemy_starts_turn
 
 
-func _ready() -> void:
-	EventBusHandler.enemies_start_of_turn_resolved.connect(_on_event_bus_enemies_start_of_turn_resolved)
-
 func enter():
 	print("Entered EnemyStartTurn")
 	# resolve enemy start of turn effects
@@ -14,6 +11,3 @@ func enter():
 
 func exit():
 	print("Exited EnemyStartTurn")
-
-func _on_event_bus_enemies_start_of_turn_resolved():
-	state_machine.transition_to("EnemyTurn")

--- a/scripts/battle/state_machine/enemy_start_turn.gd
+++ b/scripts/battle/state_machine/enemy_start_turn.gd
@@ -5,7 +5,7 @@ signal enemy_starts_turn
 
 
 func _ready() -> void:
-	EventBusHandler.enemies_start_of_turn_resolved.connect(_on_event_bus_handle_enemies_start_of_turn_resolved)
+	EventBusHandler.enemies_start_of_turn_resolved.connect(_on_event_bus_enemies_start_of_turn_resolved)
 
 func enter():
 	print("Entered EnemyStartTurn")
@@ -15,5 +15,5 @@ func enter():
 func exit():
 	print("Exited EnemyStartTurn")
 
-func _on_event_bus_handle_enemies_start_of_turn_resolved():
+func _on_event_bus_enemies_start_of_turn_resolved():
 	state_machine.transition_to("EnemyTurn")

--- a/scripts/battle/state_machine/enemy_start_turn.gd
+++ b/scripts/battle/state_machine/enemy_start_turn.gd
@@ -3,13 +3,17 @@ extends State
 
 signal enemy_starts_turn
 
+
+func _ready() -> void:
+	EventBusHandler.enemies_start_of_turn_resolved.connect(_on_event_bus_handle_enemies_start_of_turn_resolved)
+
 func enter():
 	print("Entered EnemyStartTurn")
-	# 1. resolve enemy start of turn effects
+	# resolve enemy start of turn effects
 	enemy_starts_turn.emit()
-	# 2. enter state enemy_turn
-	await get_tree().create_timer(1.0).timeout
-	state_machine.transition_to("EnemyTurn")
 
 func exit():
 	print("Exited EnemyStartTurn")
+
+func _on_event_bus_handle_enemies_start_of_turn_resolved():
+	state_machine.transition_to("EnemyTurn")

--- a/scripts/battle/state_machine/enemy_turn.gd
+++ b/scripts/battle/state_machine/enemy_turn.gd
@@ -5,7 +5,7 @@ signal resolve_enemy_intents
 
 
 func _ready() -> void:
-	EventBusHandler.enemies_turn_resolved.connect(_on_event_bus_handler_enemies_turn_resolved)
+	EventBusHandler.enemies_turn_resolved.connect(_on_event_bus_enemies_turn_resolved)
 
 func enter():
 	print("Entered EnemyTurn")
@@ -15,5 +15,5 @@ func enter():
 func exit():
 	print("Exited EnemyTurn")
 
-func _on_event_bus_handler_enemies_turn_resolved():
+func _on_event_bus_enemies_turn_resolved():
 	state_machine.transition_to("EnemyEndTurn")

--- a/scripts/battle/state_machine/enemy_turn.gd
+++ b/scripts/battle/state_machine/enemy_turn.gd
@@ -4,9 +4,6 @@ extends State
 signal resolve_enemy_intents
 
 
-func _ready() -> void:
-	EventBusHandler.enemies_turn_resolved.connect(_on_event_bus_enemies_turn_resolved)
-
 func enter():
 	print("Entered EnemyTurn")
 	# resolve enemy intent
@@ -14,6 +11,3 @@ func enter():
 
 func exit():
 	print("Exited EnemyTurn")
-
-func _on_event_bus_enemies_turn_resolved():
-	state_machine.transition_to("EnemyEndTurn")

--- a/scripts/battle/state_machine/enemy_turn.gd
+++ b/scripts/battle/state_machine/enemy_turn.gd
@@ -3,13 +3,17 @@ extends State
 
 signal resolve_enemy_intents
 
+
+func _ready() -> void:
+	EventBusHandler.enemies_turn_resolved.connect(_on_event_bus_handler_enemies_turn_resolved)
+
 func enter():
 	print("Entered EnemyTurn")
-	# 1. resolve enemy intent
+	# resolve enemy intent
 	resolve_enemy_intents.emit()
-	# 2. enter state enemy_end_turn
-	await get_tree().create_timer(1.0).timeout
-	state_machine.transition_to("EnemyEndTurn")
 
 func exit():
 	print("Exited EnemyTurn")
+
+func _on_event_bus_handler_enemies_turn_resolved():
+	state_machine.transition_to("EnemyEndTurn")

--- a/scripts/battle/state_machine/idle.gd
+++ b/scripts/battle/state_machine/idle.gd
@@ -4,6 +4,7 @@ extends State
 signal entered_idle
 signal exited_idle
 
+
 func _ready():
 	EventBusHandler.end_turn_button_pressed.connect(_on_event_bus_end_turn_button_pressed)
 

--- a/scripts/battle/state_machine/player_end_turn.gd
+++ b/scripts/battle/state_machine/player_end_turn.gd
@@ -4,9 +4,6 @@ extends State
 signal player_ends_turn
 
 
-func _ready() -> void:
-	EventBusHandler.player_end_of_turn_resolved.connect(_on_event_bus_player_end_of_turn_resolved)
-
 func enter():
 	print("Entered PlayerEndTurn")
 	# resolve player end of turn effects
@@ -14,6 +11,3 @@ func enter():
 
 func exit():
 	print("Exited PlayerEndTurn")
-
-func _on_event_bus_player_end_of_turn_resolved():
-	state_machine.transition_to("EnemyStartTurn")

--- a/scripts/battle/state_machine/player_end_turn.gd
+++ b/scripts/battle/state_machine/player_end_turn.gd
@@ -1,21 +1,19 @@
 class_name PlayerEndTurn
 extends State
 
-signal discard_hand
 signal player_ends_turn
+
+
+func _ready() -> void:
+	EventBusHandler.player_end_of_turn_resolved.connect(_on_event_bus_handler_player_end_of_turn_resolved)
 
 func enter():
 	print("Entered PlayerEndTurn")
-	
-	# 1. resolve player end of turn effects
+	# resolve player end of turn effects
 	player_ends_turn.emit()
-	# 2. discard hand
-	await get_tree().create_timer(0.5).timeout
-	discard_hand.emit()
-	
-	# 3. enter state enemy_start_turn
-	await get_tree().create_timer(1.0).timeout
-	state_machine.transition_to("EnemyStartTurn")
 
 func exit():
 	print("Exited PlayerEndTurn")
+
+func _on_event_bus_handler_player_end_of_turn_resolved():
+	state_machine.transition_to("EnemyStartTurn")

--- a/scripts/battle/state_machine/player_end_turn.gd
+++ b/scripts/battle/state_machine/player_end_turn.gd
@@ -5,7 +5,7 @@ signal player_ends_turn
 
 
 func _ready() -> void:
-	EventBusHandler.player_end_of_turn_resolved.connect(_on_event_bus_handler_player_end_of_turn_resolved)
+	EventBusHandler.player_end_of_turn_resolved.connect(_on_event_bus_player_end_of_turn_resolved)
 
 func enter():
 	print("Entered PlayerEndTurn")
@@ -15,5 +15,5 @@ func enter():
 func exit():
 	print("Exited PlayerEndTurn")
 
-func _on_event_bus_handler_player_end_of_turn_resolved():
+func _on_event_bus_player_end_of_turn_resolved():
 	state_machine.transition_to("EnemyStartTurn")

--- a/scripts/battle/state_machine/player_start_turn.gd
+++ b/scripts/battle/state_machine/player_start_turn.gd
@@ -1,23 +1,19 @@
 class_name PlayerStartTurn
 extends State
 
-signal choose_enemy_intents
-signal draw_cards
 signal player_starts_turn
+
+
+func _ready() -> void:
+	EventBusHandler.player_start_of_turn_resolved.connect(_on_event_bus_handler_player_start_of_turn_resolved)
 
 func enter():
 	print("Entered PlayerStartTurn")
-	# 1. choose enemy intents
-	choose_enemy_intents.emit()
-	# 2. the player starts its turn
-	await get_tree().create_timer(0.2).timeout
+	# choose enemy intents and resolve player start of turn effects
 	player_starts_turn.emit()
-	# 3. draw cards
-	await get_tree().create_timer(0.2).timeout
-	draw_cards.emit()
-	# 4. enter state idle
-	await get_tree().create_timer(1.0).timeout
-	state_machine.transition_to("Idle")
 
 func exit():
 	print("Exited PlayerStartTurn")
+
+func _on_event_bus_handler_player_start_of_turn_resolved():
+	state_machine.transition_to("Idle")

--- a/scripts/battle/state_machine/player_start_turn.gd
+++ b/scripts/battle/state_machine/player_start_turn.gd
@@ -4,9 +4,6 @@ extends State
 signal player_starts_turn
 
 
-func _ready() -> void:
-	EventBusHandler.player_start_of_turn_resolved.connect(_on_event_bus_player_start_of_turn_resolved)
-
 func enter():
 	print("Entered PlayerStartTurn")
 	# choose enemy intents and resolve player start of turn effects
@@ -14,6 +11,3 @@ func enter():
 
 func exit():
 	print("Exited PlayerStartTurn")
-
-func _on_event_bus_player_start_of_turn_resolved():
-	state_machine.transition_to("Idle")

--- a/scripts/battle/state_machine/player_start_turn.gd
+++ b/scripts/battle/state_machine/player_start_turn.gd
@@ -5,7 +5,7 @@ signal player_starts_turn
 
 
 func _ready() -> void:
-	EventBusHandler.player_start_of_turn_resolved.connect(_on_event_bus_handler_player_start_of_turn_resolved)
+	EventBusHandler.player_start_of_turn_resolved.connect(_on_event_bus_player_start_of_turn_resolved)
 
 func enter():
 	print("Entered PlayerStartTurn")
@@ -15,5 +15,5 @@ func enter():
 func exit():
 	print("Exited PlayerStartTurn")
 
-func _on_event_bus_handler_player_start_of_turn_resolved():
+func _on_event_bus_player_start_of_turn_resolved():
 	state_machine.transition_to("Idle")

--- a/scripts/battle/state_machine/state.gd
+++ b/scripts/battle/state_machine/state.gd
@@ -7,4 +7,4 @@ func enter():
 	pass
 
 func exit():
-	pass	# cleanup logic (disconnecting signals, stopping timers, etc.)
+	pass

--- a/scripts/characters/player.gd
+++ b/scripts/characters/player.gd
@@ -30,10 +30,10 @@ func gain_block(amount: int) -> void:
 func start_of_turn() -> void:
 	stats.current_energy = stats.maximum_energy
 	stats.block = 0
-	effect_handler._on_unit_turn_start()
+	await effect_handler._on_unit_turn_start()
 
 func end_of_turn() -> void:
-	effect_handler._on_unit_turn_end()
+	await effect_handler._on_unit_turn_end()
 
 func initialize() -> void:
 	# Connecting Signals

--- a/scripts/effects/effect_handler.gd
+++ b/scripts/effects/effect_handler.gd
@@ -147,10 +147,12 @@ func _on_effect_remove_effect(target: Effect) -> void:
 func _on_unit_turn_end() -> void:
 	for effect: Effect in effect_collection.get_children():
 		effect.end_of_turn()
+		await get_tree().create_timer(0.1).timeout
 
 func _on_unit_turn_start() -> void:
 	for effect: Effect in effect_collection.get_children():
 		effect.start_of_turn()
+		await get_tree().create_timer(0.1).timeout
 
 func _on_unit_get_attacked() -> void:
 	for effect: Effect in effect_collection.get_children():

--- a/scripts/enemy/enemy.gd
+++ b/scripts/enemy/enemy.gd
@@ -12,7 +12,7 @@ const INTENT_COLOR_BLOCK: Color = Color.SKY_BLUE
 @onready var image: Sprite2D = $EnemyImage
 @onready var shape: CollisionShape2D = $EnemyShape
 @onready var modifier_handler: ModifierHandler = $ModifierHandler
-@onready var effect_handler = $EffectHandler
+@onready var effect_handler: EffectHandler = $EffectHandler
 @onready var highlights = $Highlights
 @onready var hit_frame_timer: Timer = $HitFrameTimer
 
@@ -56,10 +56,10 @@ func initialize() -> void:
 
 func start_of_turn() -> void:
 	stats.block = 0
-	effect_handler._on_unit_turn_start()
+	await effect_handler._on_unit_turn_start()
 
 func end_of_turn() -> void:
-	effect_handler._on_unit_turn_end()
+	await effect_handler._on_unit_turn_end()
 
 func take_damage(amount:int) -> void:
 	image.material.set_shader_parameter("intensity", 1.0)

--- a/scripts/global/event_bus_handler.gd
+++ b/scripts/global/event_bus_handler.gd
@@ -6,11 +6,6 @@ extends Node
 signal battle_started
 signal battle_ended
 signal end_turn_button_pressed
-signal player_start_of_turn_resolved
-signal player_end_of_turn_resolved
-signal enemies_start_of_turn_resolved
-signal enemies_turn_resolved
-signal enemies_end_of_turn_resolved
 signal player_played_attack
 signal set_player_control(value: bool)
 signal open_settings
@@ -39,18 +34,3 @@ func clear_all_battle_events() -> void:
 	
 	for function in card_piles_card_count_changed.get_connections():
 		card_piles_card_count_changed.disconnect(function["callable"])
-	
-	for function in player_start_of_turn_resolved.get_connections():
-		player_start_of_turn_resolved.disconnect(function["callable"])
-	
-	for function in player_end_of_turn_resolved.get_connections():
-		player_end_of_turn_resolved.disconnect(function["callable"])
-	
-	for function in enemies_start_of_turn_resolved.get_connections():
-		enemies_start_of_turn_resolved.disconnect(function["callable"])
-	
-	for function in enemies_turn_resolved.get_connections():
-		enemies_turn_resolved.disconnect(function["callable"])
-	
-	for function in enemies_end_of_turn_resolved.get_connections():
-		enemies_end_of_turn_resolved.disconnect(function["callable"])

--- a/scripts/global/event_bus_handler.gd
+++ b/scripts/global/event_bus_handler.gd
@@ -6,6 +6,11 @@ extends Node
 signal battle_started
 signal battle_ended
 signal end_turn_button_pressed
+signal player_start_of_turn_resolved
+signal player_end_of_turn_resolved
+signal enemies_start_of_turn_resolved
+signal enemies_turn_resolved
+signal enemies_end_of_turn_resolved
 signal player_played_attack
 signal set_player_control(value: bool)
 signal open_settings
@@ -34,3 +39,18 @@ func clear_all_battle_events() -> void:
 	
 	for function in card_piles_card_count_changed.get_connections():
 		card_piles_card_count_changed.disconnect(function["callable"])
+	
+	for function in player_start_of_turn_resolved.get_connections():
+		player_start_of_turn_resolved.disconnect(function["callable"])
+	
+	for function in player_end_of_turn_resolved.get_connections():
+		player_end_of_turn_resolved.disconnect(function["callable"])
+	
+	for function in enemies_start_of_turn_resolved.get_connections():
+		enemies_start_of_turn_resolved.disconnect(function["callable"])
+	
+	for function in enemies_turn_resolved.get_connections():
+		enemies_turn_resolved.disconnect(function["callable"])
+	
+	for function in enemies_end_of_turn_resolved.get_connections():
+		enemies_end_of_turn_resolved.disconnect(function["callable"])


### PR DESCRIPTION
state machine transitions are now triggered via signals in the EBH instead of a fixed timer, which was just bad and i don't know why i did that in the first place

closes #363