### PR TITLE
feat: run ui, map and deck view visible over card rewards

### DIFF
--- a/scenes/encounters/battle_rewards.tscn
+++ b/scenes/encounters/battle_rewards.tscn
@@ -12,16 +12,15 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 theme = ExtResource("1_ophfa")
 script = ExtResource("1_cx4uy")
 
 [node name="RewardSelection" type="ColorRect" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+layout_mode = 0
+offset_top = 22.0
+offset_right = 320.0
+offset_bottom = 180.0
 color = Color(0, 0, 0, 0.67451)
 
 [node name="CenterPanel" type="Panel" parent="RewardSelection"]

--- a/scenes/map/map.tscn
+++ b/scenes/map/map.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://ldxb6li1pp6t" path="res://assets/graphics/map/map_sprite.png" id="3_ph54e"]
 
 [node name="Map" type="Control"]
-z_index = -1
+z_index = 9
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -15,7 +15,6 @@ offset_top = 2.0
 offset_bottom = 2.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 2
 theme = ExtResource("1_a2pkv")
 script = ExtResource("1_sxf4j")
 
@@ -31,7 +30,7 @@ theme_override_constants/margin_top = 20
 
 [node name="MapBackground" type="TextureRect" parent="TopMargin"]
 layout_mode = 2
-mouse_filter = 2
+mouse_filter = 0
 texture = ExtResource("3_ph54e")
 
 [node name="MapIconsMargin" type="MarginContainer" parent="TopMargin"]
@@ -57,12 +56,16 @@ size_flags_vertical = 3
 mouse_filter = 2
 theme_override_constants/separation = 32
 
-[node name="ExitButton" type="Button" parent="TopMargin"]
+[node name="ExitButton" type="Button" parent="."]
 visible = false
 z_index = 2
-layout_mode = 2
+layout_mode = 0
+offset_left = 303.0
+offset_top = 24.0
+offset_right = 316.0
+offset_bottom = 38.0
 size_flags_horizontal = 8
 size_flags_vertical = 0
-text = " x "
+text = "x"
 
-[connection signal="pressed" from="TopMargin/ExitButton" to="." method="_on_exit_button_pressed"]
+[connection signal="pressed" from="ExitButton" to="." method="_on_exit_button_pressed"]

--- a/scenes/run.tscn
+++ b/scenes/run.tscn
@@ -11,19 +11,42 @@
 [node name="Run" type="Node2D"]
 script = ExtResource("1_q5lik")
 
+[node name="BackgroundTexture" type="Sprite2D" parent="."]
+
 [node name="UILayer" type="CanvasLayer" parent="."]
 script = ExtResource("2_dqgnb")
 
-[node name="RunUI" parent="UILayer" instance=ExtResource("4_nafsq")]
-offset_bottom = 18.0
-size_flags_vertical = 0
+[node name="LowerLevelUI" type="Control" parent="UILayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 
-[node name="Map" parent="UILayer" instance=ExtResource("3_6ock1")]
-visible = false
+[node name="UpperLevelUI" type="Control" parent="UILayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
 
-[node name="DeckView" parent="UILayer" instance=ExtResource("5_nafsq")]
+[node name="Map" parent="UILayer/UpperLevelUI" instance=ExtResource("3_6ock1")]
 visible = false
+layout_mode = 1
+
+[node name="DeckView" parent="UILayer/UpperLevelUI" instance=ExtResource("5_nafsq")]
+visible = false
+layout_mode = 1
+
+[node name="RunUI" parent="UILayer/UpperLevelUI" instance=ExtResource("4_nafsq")]
+layout_mode = 1
+offset_bottom = 24.0
+size_flags_vertical = 0
+mouse_filter = 2
 
 [node name="EncounterHandler" type="Node2D" parent="."]
 script = ExtResource("2_6ock1")
@@ -34,10 +57,10 @@ unique_name_in_owner = true
 [node name="MapGenerator" type="Node2D" parent="."]
 script = ExtResource("7_nafsq")
 
-[connection signal="open_deck_view" from="UILayer/RunUI" to="UILayer" method="_on_run_ui_open_deck_view"]
-[connection signal="open_map" from="UILayer/RunUI" to="UILayer" method="_on_run_ui_open_map"]
-[connection signal="encounter_selected" from="UILayer/Map" to="." method="_on_map_encounter_selected"]
-[connection signal="hidden" from="UILayer/Map" to="UILayer" method="_on_map_hidden"]
-[connection signal="close_deck_view" from="UILayer/DeckView" to="UILayer" method="_close_deck_view"]
+[connection signal="encounter_selected" from="UILayer/UpperLevelUI/Map" to="." method="_on_map_encounter_selected"]
+[connection signal="hidden" from="UILayer/UpperLevelUI/Map" to="UILayer" method="_on_map_hidden"]
+[connection signal="close_deck_view" from="UILayer/UpperLevelUI/DeckView" to="UILayer" method="_close_deck_view"]
+[connection signal="open_deck_view" from="UILayer/UpperLevelUI/RunUI" to="UILayer" method="_on_run_ui_open_deck_view"]
+[connection signal="open_map" from="UILayer/UpperLevelUI/RunUI" to="UILayer" method="_on_run_ui_open_map"]
 [connection signal="load_main_menu" from="EncounterHandler" to="." method="_on_encounter_handler_load_main_menu"]
 [connection signal="load_rewards" from="EncounterHandler" to="." method="_on_encounter_handler_load_rewards"]

--- a/scenes/ui/deck_view.tscn
+++ b/scenes/ui/deck_view.tscn
@@ -5,23 +5,22 @@
 [ext_resource type="PackedScene" uid="uid://c548kbb7afp6r" path="res://scenes/ui/tooltip.tscn" id="3_j3w2u"]
 
 [node name="DeckView" type="Control"]
+z_index = 9
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 2
 theme = ExtResource("1_xu8pb")
 script = ExtResource("1_8w67t")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="BackgroundColor" type="ColorRect" parent="."]
 layout_mode = 0
 offset_top = 23.0
 offset_right = 320.0
 offset_bottom = 180.0
-mouse_filter = 2
-color = Color(0, 0, 0, 1)
+color = Color(0, 0, 0, 0.67451)
 
 [node name="ScrollContainerMargin" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -36,6 +35,7 @@ theme_override_constants/margin_top = 32
 [node name="CardScrollContainer" type="ScrollContainer" parent="ScrollContainerMargin"]
 layout_mode = 2
 size_flags_horizontal = 4
+mouse_filter = 2
 horizontal_scroll_mode = 0
 vertical_scroll_mode = 3
 
@@ -70,6 +70,8 @@ text = "x"
 [node name="Tooltip" parent="UIMargin" instance=ExtResource("3_j3w2u")]
 visible = false
 layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
 
 [node name="ActionButton" type="Button" parent="UIMargin"]
 visible = false

--- a/scenes/ui/run_ui.tscn
+++ b/scenes/ui/run_ui.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://c548kbb7afp6r" path="res://scenes/ui/tooltip.tscn" id="8_5gf5s"]
 
 [node name="RunUI" type="TextureRect"]
+z_index = 10
 custom_minimum_size = Vector2(0, 20)
 anchors_preset = 10
 anchor_right = 1.0

--- a/scripts/map/map.gd
+++ b/scripts/map/map.gd
@@ -3,7 +3,7 @@ extends Control
 
 signal encounter_selected(encounter_data)
 
-@onready var exit_button: Button = $TopMargin/ExitButton
+@onready var exit_button: Button = $ExitButton
 @onready var map_layer_container = $TopMargin/MapIconsMargin/MapScrollContainer/MapLayerContainer
 @onready var connection_drawer: MapConnectionDrawer = $TopMargin/MapIconsMargin/MapConnectionDrawer
 @onready var scroll_container: ScrollContainer = $TopMargin/MapIconsMargin/MapScrollContainer

--- a/scripts/run/encounter_handler.gd
+++ b/scripts/run/encounter_handler.gd
@@ -5,7 +5,7 @@ signal load_main_menu
 signal load_rewards(boss_rewards: bool)
 
 @onready var run: Run = $".."
-@onready var map: Map = $"../UILayer/Map"
+@onready var map: Map = $"../UILayer/UpperLevelUI/Map"
 
 const GAME_OVER_SCREEN: PackedScene = preload("res://scenes/ui/game_over_screen.tscn")
 const WIN_SCREEN: PackedScene = preload("res://scenes/ui/win_screen.tscn")

--- a/scripts/run/run.gd
+++ b/scripts/run/run.gd
@@ -4,9 +4,9 @@ extends Node2D
 signal load_main_menu
 
 @onready var ui_layer: UILayer = $UILayer
-@onready var run_ui: RunUI = $UILayer/RunUI
+@onready var run_ui: RunUI = $UILayer/UpperLevelUI/RunUI
 @onready var encounter_handler = $EncounterHandler
-@onready var map = $UILayer/Map
+@onready var map = $UILayer/UpperLevelUI/Map
 @onready var map_generator = $MapGenerator
 
 var map_layers: Array[MapLayer] = []

--- a/scripts/ui/deck_view.gd
+++ b/scripts/ui/deck_view.gd
@@ -8,11 +8,13 @@ const CARD_VISUALIZATION = preload("res://scenes/card/card_visualization.tscn")
 @onready var card_container = $ScrollContainerMargin/CardScrollContainer/CardContainer
 @onready var tooltip = $UIMargin/Tooltip
 @onready var action_button: Button = $UIMargin/ActionButton
+@onready var background_color: ColorRect = $BackgroundColor
 
 var card_selected_action: Callable
 var has_action_button: bool = false
 var button_action: Callable
 var exit_action: Callable
+
 
 func load_cards(card_pile: Array[CardType]) -> void:
 	if not is_node_ready():
@@ -43,6 +45,9 @@ func add_button_action(on_button_pressed_action: Callable) -> void:
 
 func add_exit_action(on_exit_pressed_action: Callable) -> void:
 	exit_action = on_exit_pressed_action
+
+func set_background_color(color: Color) -> void:
+	background_color.color = color
 
 func _on_exit_pressed() -> void:
 	for card: CardVisualization in card_container.get_children():


### PR DESCRIPTION
divided run UI into lower and upper level ui, changed mouse input logic, added function to change background color in deck view to make it black when it would be up against the default godot background

closes #386